### PR TITLE
Add Support for GNOME Shell 46-48

### DIFF
--- a/yetanotherradio@io.github.buddysirjava/metadata.json
+++ b/yetanotherradio@io.github.buddysirjava/metadata.json
@@ -1,10 +1,13 @@
 {
-  "name": "Yet Another Radio",
-  "description": "Listen to internet radio easily!",
-  "uuid": "yetanotherradio@io.github.buddysirjava",
-  "shell-version": [
-    "49"
-  ],
-  "url": "https://github.com/BuddySirJava/YetAnotherRadio",
-  "gettext-domain": "yetanotherradio@io.github.buddysirjava"
+    "name": "Yet Another Radio",
+    "description": "Listen to internet radio easily!",
+    "uuid": "yetanotherradio@io.github.buddysirjava",
+    "shell-version": [
+        "46",
+        "47",
+        "48",
+        "49"
+    ],
+    "url": "https://github.com/BuddySirJava/YetAnotherRadio",
+    "gettext-domain": "yetanotherradio@io.github.buddysirjava"
 }


### PR DESCRIPTION
Hello Buddy
I noticed that the `metadata.json` currently only includes GNOME Shell version 49. However, I've successfully tested the extension on GNOME Shell 46, and it works well after addressing a minor schema compilation issue.
Changes

Added GNOME Shell versions 46, 47, and 48 to metadata.json

Testing

✅ Tested on GNOME Shell 46
Extension functions correctly after schema compilation

Known Issues
There are some minor issues that I encountered during testing. I will create a separate issue to document and discuss these in detail.
Recommendation
Consider adding a post-install note or script to ensure gschemas.compiled is generated, as users may encounter an ERROR state without it: