### PR TITLE
Fix Playback Manager Styles

### DIFF
--- a/yetanotherradio@io.github.buddysirjava/modules/metadataDisplay.js
+++ b/yetanotherradio@io.github.buddysirjava/modules/metadataDisplay.js
@@ -60,7 +60,7 @@ export function createMetadataItem(playPauseCallback, stopCallback) {
     bottomRow.add_child(qualityLabel);
 
     const controlsBox = new St.BoxLayout({
-        style_class: 'metadata-controls-pill',
+        style_class: 'button metadata-controls-pill',
         vertical: false,
         x_align: Clutter.ActorAlign.END,
         y_align: Clutter.ActorAlign.CENTER,
@@ -76,7 +76,7 @@ export function createMetadataItem(playPauseCallback, stopCallback) {
     });
 
     const playPauseBtn = new St.Button({
-        style_class: 'metadata-overlay-button',
+        style_class: 'icon-button metadata-overlay-button',
         child: new St.Icon({
             icon_name: 'media-playback-pause-symbolic',
             style_class: 'metadata-overlay-icon'
@@ -86,7 +86,7 @@ export function createMetadataItem(playPauseCallback, stopCallback) {
     controlsBox.add_child(playPauseBtn);
 
     const stopBtn = new St.Button({
-        style_class: 'metadata-overlay-button',
+        style_class: 'icon-button metadata-overlay-button',
         child: new St.Icon({
             icon_name: 'media-playback-stop-symbolic',
             style_class: 'metadata-overlay-icon'
@@ -330,4 +330,3 @@ export function loadStationIcon(item, faviconUrl) {
         console.debug(e);
     }
 }
-

--- a/yetanotherradio@io.github.buddysirjava/stylesheet.css
+++ b/yetanotherradio@io.github.buddysirjava/stylesheet.css
@@ -1,4 +1,4 @@
-.metadata-item-box {    
+.metadata-item-box {
     spacing: 12px;
     padding: 8px;
 }
@@ -23,7 +23,6 @@
 
 .metadata-artist {
     font-size: 0.9em;
-    color: rgba(255, 255, 255, 0.7);
     max-width: 180px !important;
     width: 180px !important;
 }
@@ -35,7 +34,6 @@
 
 .metadata-quality {
     font-size: 0.85em;
-    color: rgba(255, 255, 255, 0.5);
 }
 
 preferencespage preferencesgroup button {
@@ -127,7 +125,6 @@ preferencespage preferencesgroup actionrow:hover {
 }
 
 .metadata-controls-pill {
-    background-color: rgba(255, 255, 255, 0.1);
     border-radius: 24px;
     padding: 2px;
 }
@@ -151,5 +148,4 @@ preferencespage preferencesgroup actionrow:hover {
 
 .metadata-overlay-icon {
     icon-size: 16px;
-    color: white;
 }


### PR DESCRIPTION
Uses standard GNOME Shell style class names for buttons to ensure consistency between different themes. Also, uses normal color for the artist name and title labels to make sure they are visible in all themes.

Fixes #16