### PR TITLE
Change Gst.init argument from null to empty array

### DIFF
--- a/yetanotherradio@io.github.buddysirjava/modules/playbackManager.js
+++ b/yetanotherradio@io.github.buddysirjava/modules/playbackManager.js
@@ -41,7 +41,7 @@ export default class PlaybackManager {
 
     _initGst() {
         if (!Gst.is_initialized()) {
-            Gst.init(null);
+            Gst.init([]);
         }
     }
 


### PR DESCRIPTION
These changes are fully backward compatible.

The update from null to [] in Gst.init() follows the official GStreamer/GJS documentation. Older GNOME versions handled null loosely by converting it internally, but the current GJS version in GNOME 49+ (and especially on rolling-release distros like Arch) has become stricter and now requires the explicit array type to prevent a crash.